### PR TITLE
Add transactional annotations on service layer methods 

### DIFF
--- a/Market-Trading-System/src/main/java/ServiceLayer/Market/SystemManagerService.java
+++ b/Market-Trading-System/src/main/java/ServiceLayer/Market/SystemManagerService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.ws.rs.core.Response;
 
@@ -86,6 +87,7 @@ public class SystemManagerService implements ISystemManagerService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> closeStore(String token, long storeId) {
         try {
@@ -106,6 +108,7 @@ public class SystemManagerService implements ISystemManagerService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> closeMarket(String token) {
         return null;

--- a/Market-Trading-System/src/main/java/ServiceLayer/Store/StoreManagementService.java
+++ b/Market-Trading-System/src/main/java/ServiceLayer/Store/StoreManagementService.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.ws.rs.core.Response;
 import java.util.*;
@@ -55,6 +56,7 @@ public class StoreManagementService implements IStoreManagementService {
         instance = null;
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> createStore(String founderToken, String storeName, String storeDescription) {
         try {
@@ -74,6 +76,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> addItemToStore(String token, long storeId, String itemName, String description, double itemPrice, int stockAmount, List<String> categories) {
         try {
@@ -92,6 +95,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> updateItem(String token, long storeId, long itemId, String newName, double newPrice, int newAmount) {
         try {
@@ -110,6 +114,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> deleteItem(String token, long storeId, long itemId) {
         try {
@@ -128,6 +133,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> changeStorePolicy(String token, long storeId) {
         try {
@@ -146,6 +152,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> changeDiscountType(String token, long storeId, String newType) {
         try {
@@ -164,6 +171,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> removeStore(String token, long storeId) {
         try {
@@ -233,6 +241,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> assignStoreOwner(String token, long storeId, String newOwnerId) {
         try {
@@ -251,6 +260,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> assignStoreManager(String token, long storeId, String newManagerI, List<String> permissions) {
         try {
@@ -269,6 +279,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> addDiscount(String token, long storeId, String discountDetails) {
         try {
@@ -287,6 +298,7 @@ public class StoreManagementService implements IStoreManagementService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<?> addPolicy(String token, long storeId, String policyDetails) {
         try {

--- a/Market-Trading-System/src/main/java/ServiceLayer/User/UserService.java
+++ b/Market-Trading-System/src/main/java/ServiceLayer/User/UserService.java
@@ -15,6 +15,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Date;
 import java.util.List;
 
@@ -138,6 +140,7 @@ public class UserService implements IUserService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> modifyShoppingCart(String token, long basketId, long itemId, int newQuantity) {
         try {
@@ -157,6 +160,7 @@ public class UserService implements IUserService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> addItemToBasket(String token, long storeId, long itemId, int quantity) {
         try {
@@ -175,6 +179,7 @@ public class UserService implements IUserService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> addPermission(String token, String userToPermit, long storeId, String permission) {
         try {
@@ -194,6 +199,7 @@ public class UserService implements IUserService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> removePermission(String token, String userToUnPermit, long storeId, String permission) {
         try {
@@ -212,6 +218,7 @@ public class UserService implements IUserService {
             return ResponseEntity.status(500).body("Error removing permission");
         }
     }
+
 
     @Override
     public ResponseEntity<?> getShoppingCart(String token) {
@@ -232,6 +239,7 @@ public class UserService implements IUserService {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
+
 
     @Override
     public ResponseEntity<List<Long>> viewUserStoresOwnership(String token) {
@@ -271,6 +279,7 @@ public class UserService implements IUserService {
         }
     }
 
+    @Transactional
     @Override
     public ResponseEntity<String> checkoutShoppingCart(String token, String creditCard, Date expiryDate, String cvv, String discountCode) {
         try {


### PR DESCRIPTION
Add transactional annotation on service layer methods that make changes in the database and only if it yields to more than one database query modifying